### PR TITLE
fix attributes validation

### DIFF
--- a/lib/sib-api-v3-sdk/models/update_contact.rb
+++ b/lib/sib-api-v3-sdk/models/update_contact.rb
@@ -61,7 +61,7 @@ module SibApiV3Sdk
       attributes = attributes.each_with_object({}){|(k,v), h| h[k.to_sym] = v}
 
       if attributes.has_key?(:'attributes')
-        if (value = attributes[:'attributes']).is_a?(Array)
+        if (value = attributes[:'attributes']).is_a?(Hash)
           self.attributes = value
         end
       end


### PR DESCRIPTION
switch validation from Array to Hash

when trying to initiate  UpdateContact with "attributes" property of Hash type, the constructor validation filters it due to "Array" validation

api_instance = SibApiV3Sdk::ContactsApi.new

email = "test@gmail.com" # String | Email (urlencoded) of the contact

update_contact = SibApiV3Sdk::UpdateContact.new # UpdateContact | Values to update a contact
update_contact = {
    'attributes'=> {
        'foo'=> 'bar'
    },
    'listds' => [1],
    'unlinkListIds' => []
  };

begin
  #Updates a contact
  api_instance.update_contact(email, update_contact)
rescue SibApiV3Sdk::ApiError => e
  puts "Exception when calling ContactsApi->update_contact: #{e}"
end