### PR TITLE
Fix exception error due to blank date on get_email_campaign method

### DIFF
--- a/lib/sib-api-v3-sdk/models/get_email_campaign.rb
+++ b/lib/sib-api-v3-sdk/models/get_email_campaign.rb
@@ -519,7 +519,7 @@ module SibApiV3Sdk
     def _deserialize(type, value)
       case type.to_sym
       when :DateTime
-        DateTime.parse(value)
+        DateTime.parse(value) if value.present?
       when :Date
         Date.parse(value)
       when :String


### PR DESCRIPTION
Date::Error (invalid date)

refs #38