### PR TITLE
Added 'error' event type to allowable_values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    sib-api-v3-sdk (7.1.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.12.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    autotest-fsevent (0.2.17)
+      sys-uname
+    autotest-growl (0.2.16)
+    autotest-rails-pure (4.1.2)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.4.4)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
+    ffi (1.14.2)
+    hashdiff (1.0.1)
+    json (2.5.1)
+    public_suffix (4.0.6)
+    rake (13.0.3)
+    rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autotest (~> 4.4, >= 4.4.6)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
+  autotest-growl (~> 0.2, >= 0.2.16)
+  autotest-rails-pure (~> 4.1, >= 4.1.2)
+  rake (>= 12.3.3)
+  rspec (~> 3.6, >= 3.6.0)
+  sib-api-v3-sdk!
+  vcr (~> 3.0, >= 3.0.1)
+  webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   2.1.4

--- a/lib/sib-api-v3-sdk/models/get_email_event_report_events.rb
+++ b/lib/sib-api-v3-sdk/models/get_email_event_report_events.rb
@@ -48,7 +48,7 @@ module SibApiV3Sdk
       attr_reader :datatype
       attr_reader :allowable_values
 
-      ALLOWABLE_VALUES = %w(bounces hardBounces softBounces delivered spam requests opened clicks invalid deferred blocked unsubscribed)
+      ALLOWABLE_VALUES = %w(bounces hardBounces softBounces delivered spam requests opened clicks invalid deferred blocked unsubscribed error)
 
       def initialize(datatype, allowable_values)
         @allowable_values = allowable_values.map do |value|

--- a/lib/sib-api-v3-sdk/models/get_email_event_report_events.rb
+++ b/lib/sib-api-v3-sdk/models/get_email_event_report_events.rb
@@ -1,7 +1,7 @@
 =begin
 #SendinBlue API
 
-#SendinBlue provide a RESTFul API that can be used with any languages. With this API, you will be able to :   - Manage your campaigns and get the statistics   - Manage your contacts   - Send transactional Emails and SMS   - and much more...  You can download our wrappers at https://github.com/orgs/sendinblue  **Possible responses**   | Code | Message |   | :-------------: | ------------- |   | 200  | OK. Successful Request  |   | 201  | OK. Successful Creation |   | 202  | OK. Request accepted |   | 204  | OK. Successful Update/Deletion  |   | 400  | Error. Bad Request  |   | 401  | Error. Authentication Needed  |   | 402  | Error. Not enough credit, plan upgrade needed  |   | 403  | Error. Permission denied  |   | 404  | Error. Object does not exist |   | 405  | Error. Method not allowed  |   | 406  | Error. Not Acceptable  | 
+#SendinBlue provide a RESTFul API that can be used with any languages. With this API, you will be able to :   - Manage your campaigns and get the statistics   - Manage your contacts   - Send transactional Emails and SMS   - and much more...  You can download our wrappers at https://github.com/orgs/sendinblue  **Possible responses**   | Code | Message |   | :-------------: | ------------- |   | 200  | OK. Successful Request  |   | 201  | OK. Successful Creation |   | 202  | OK. Request accepted |   | 204  | OK. Successful Update/Deletion  |   | 400  | Error. Bad Request  |   | 401  | Error. Authentication Needed  |   | 402  | Error. Not enough credit, plan upgrade needed  |   | 403  | Error. Permission denied  |   | 404  | Error. Object does not exist |   | 405  | Error. Method not allowed  |   | 406  | Error. Not Acceptable  |
 
 OpenAPI spec version: 3.0.0
 Contact: contact@sendinblue.com
@@ -47,6 +47,8 @@ module SibApiV3Sdk
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
+
+      ALLOWABLE_VALUES = %w(bounces hardBounces softBounces delivered spam requests opened clicks invalid deferred blocked unsubscribed)
 
       def initialize(datatype, allowable_values)
         @allowable_values = allowable_values.map do |value|
@@ -177,7 +179,7 @@ module SibApiV3Sdk
       return false if @date.nil?
       return false if @message_id.nil?
       return false if @event.nil?
-      event_validator = EnumAttributeValidator.new('String', ['bounces', 'hardBounces', 'softBounces', 'delivered', 'spam', 'requests', 'opened', 'clicks', 'invalid', 'deferred', 'blocked', 'unsubscribed'])
+      event_validator = EnumAttributeValidator.new('String', EnumAttributeValidator::ALLOWABLE_VALUES)
       return false unless event_validator.valid?(@event)
       true
     end
@@ -185,9 +187,9 @@ module SibApiV3Sdk
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] event Object to be assigned
     def event=(event)
-      validator = EnumAttributeValidator.new('String', ['bounces', 'hardBounces', 'softBounces', 'delivered', 'spam', 'requests', 'opened', 'clicks', 'invalid', 'deferred', 'blocked', 'unsubscribed'])
+      validator = EnumAttributeValidator.new('String', EnumAttributeValidator::ALLOWABLE_VALUES)
       unless validator.valid?(event)
-        fail ArgumentError, 'invalid value for "event", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value '#{event}' for 'event', must be one of: #{validator.allowable_values.join(', ')}."
       end
       @event = event
     end

--- a/lib/sib-api-v3-sdk/version.rb
+++ b/lib/sib-api-v3-sdk/version.rb
@@ -1,7 +1,7 @@
 =begin
 #SendinBlue API
 
-#SendinBlue provide a RESTFul API that can be used with any languages. With this API, you will be able to :   - Manage your campaigns and get the statistics   - Manage your contacts   - Send transactional Emails and SMS   - and much more...  You can download our wrappers at https://github.com/orgs/sendinblue  **Possible responses**   | Code | Message |   | :-------------: | ------------- |   | 200  | OK. Successful Request  |   | 201  | OK. Successful Creation |   | 202  | OK. Request accepted |   | 204  | OK. Successful Update/Deletion  |   | 400  | Error. Bad Request  |   | 401  | Error. Authentication Needed  |   | 402  | Error. Not enough credit, plan upgrade needed  |   | 403  | Error. Permission denied  |   | 404  | Error. Object does not exist |   | 405  | Error. Method not allowed  |   | 406  | Error. Not Acceptable  | 
+#SendinBlue provide a RESTFul API that can be used with any languages. With this API, you will be able to :   - Manage your campaigns and get the statistics   - Manage your contacts   - Send transactional Emails and SMS   - and much more...  You can download our wrappers at https://github.com/orgs/sendinblue  **Possible responses**   | Code | Message |   | :-------------: | ------------- |   | 200  | OK. Successful Request  |   | 201  | OK. Successful Creation |   | 202  | OK. Request accepted |   | 204  | OK. Successful Update/Deletion  |   | 400  | Error. Bad Request  |   | 401  | Error. Authentication Needed  |   | 402  | Error. Not enough credit, plan upgrade needed  |   | 403  | Error. Permission denied  |   | 404  | Error. Object does not exist |   | 405  | Error. Method not allowed  |   | 406  | Error. Not Acceptable  |
 
 OpenAPI spec version: 3.0.0
 Contact: contact@sendinblue.com
@@ -11,5 +11,5 @@ Swagger Codegen version: 2.4.12
 =end
 
 module SibApiV3Sdk
-  VERSION = "7.1.0"
+  VERSION = "7.1.1"
 end


### PR DESCRIPTION
The ``get_email_event_report``method was unable to correctly read events of type ``error``:

```
/Users/iwan/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/sib-api-v3-sdk-7.1.0/lib/sib-api-v3-sdk/models/get_email_event_report_events.rb:190:in `event=': invalid value for "event", must be one of #{validator.allowable_values}. (ArgumentError)
```

In my case, the error event was generated by using a disabled template.

So I added the new event type to allowable_values, and I made some refactoring.

                                                                                                                                                                  