### PR TITLE
add missing addressable gem to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,70 @@
+PATH
+  remote: .
+  specs:
+    sib-api-v3-sdk (7.4.0)
+      addressable (~> 2.8.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.12.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    autotest-fsevent (0.2.18)
+      sys-uname
+    autotest-growl (0.2.16)
+    autotest-rails-pure (4.1.2)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.4.4)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.4)
+    hashdiff (1.0.1)
+    json (2.5.1)
+    public_suffix (4.0.6)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autotest (~> 4.4, >= 4.4.6)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
+  autotest-growl (~> 0.2, >= 0.2.16)
+  autotest-rails-pure (~> 4.1, >= 4.1.2)
+  rake (>= 12.3.3)
+  rspec (~> 3.6, >= 3.6.0)
+  sib-api-v3-sdk!
+  vcr (~> 3.0, >= 3.0.1)
+  webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   2.2.22

--- a/sib-api-v3-sdk.gemspec
+++ b/sib-api-v3-sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  s.add_runtime_dependency 'addressable', '~> 2.7.0'
+  s.add_runtime_dependency 'addressable', '~> 2.8.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/sib-api-v3-sdk.gemspec
+++ b/sib-api-v3-sdk.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'addressable', '~> 2.7.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
Hi,
The latest version `7.4.0` requires `addressable/uri` in two files `configuration.rb` and `api_client.rb`.
However, the gem `addressable` isn't mentioned in the gemspec file as a runtime dependency.

This PR helps adding the missing gem
